### PR TITLE
Specifying node v0.9.1 or greater to use unref()

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     "mocha": "*",
     "should": "*"
   },
+  "engines": {
+    "node": ">= 0.9.1"
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
Recent commit on setInterval().unref() breaks on older versions of node.

[unref](http://nodejs.org/docs/v0.9.1/api/timers.html#timers_unref) feature is available only from node v0.9.1