### PR TITLE
Allow the check interval to be specified as an option

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+1.3.0 / 2019-10-25
+==================
+* Add interval to options
+
 1.2.0 / 2016-02-12
 ==================
 * Return a reference to the timer

--- a/Readme.md
+++ b/Readme.md
@@ -25,13 +25,15 @@ var timer = blocked(fn, options);
 ```
 
 * fn: The callback function to execute when the event loop is blocked. Will send in the amount of time in ms that the event loop was blocked.
-* options: _Optional._ Options object to configure the behaviour. For now, only the `threshold` option is supported. It determines the amount of ms used to determine if the function callback should be executed; useful to speed up tests 
+* options: _Optional._ Options object to configure the behaviour.
+  * `threshold` determines the amount of ms used to determine if the function callback should be executed; useful to speed up tests.
+  * `interval` determines the frequency with which the event loop is checked in ms.
 
 
 ```js
 blocked(function(ms) {
     console.log("Blocked");
-}, {threshold:1});
+}, {threshold:1, interval: 1000});
 ```
   
 Returns: A reference to the timer. Useful for clearing the timer. 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 module.exports = function (fn, options) {
     var opts = options || {};
     var start = process.hrtime();
-    var interval = 100;
+    var interval = opts.interval || 100;
     var threshold = opts.threshold || 10;
 
     return setInterval(function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blocked",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "repository": "visionmedia/node-blocked",
   "description": "check if the event loop is blocked",
   "keywords": ["block", "event", "loop", "performance"],

--- a/test/test.js
+++ b/test/test.js
@@ -16,6 +16,14 @@ describe('Blocked', function () {
         }, {threshold: 1});
     });
 
+    it('can set the interval options param', function (done) {
+        setInterval(function () { new Array(10000000).join('a'); }, 500);
+
+        this.interval = blocked(function () {
+            done();
+        }, {interval: 450});
+    });
+
     it('should not break backwards compatibility', function (done) {
         setInterval(function () { new Array(10000000).join('a'); }, 500);
 


### PR DESCRIPTION
If threshold could be set as an option, I saw no reason why the interval couldn't be specified in the same way.  Out of curiosity, is there a particular reason why the original 100 ms check interval was chosen?  I can see advantages to being able to check less frequently.

When you run the tests, the duration of the one that sets the interval to a strange value calls the `done` callback at a different time than the others:
```
  Blocked
    √ should accept the new options param (574ms)
    √ can set the interval options param (1816ms)
    √ should not break backwards compatibility (572ms)


  3 passing (3s)
```